### PR TITLE
fixed os-specific use of CLASSPATH separator

### DIFF
--- a/src/test/java/com/overstock/sample/processor/Compiler.java
+++ b/src/test/java/com/overstock/sample/processor/Compiler.java
@@ -83,7 +83,7 @@ public class Compiler {
   private static String buildClassPath(File outputDir) {
     ArrayList<String> classPathElements = Lists.newArrayList(classPathEntries);
     classPathElements.add(outputDir.getAbsolutePath());
-    return Joiner.on(":").join(classPathElements);
+    return Joiner.on(System.getProperty("path.separator")).join(classPathElements);
   }
 
   private static String classPathFor(Class<?> clazz) {


### PR DESCRIPTION
Hi Ian,

this pull request fixes an os-specific use of the CLASSPATH separator when building the classpath in com.overstock.sample.processor.Compiler 

If you try to run the unit tests on a windows machine you get (depending on the java version in use) either a nullpointerexception (java 7 - it doesn't display a nice error message) or a compiler error (package javax.persistence does not exist - java 6). 
