### PR TITLE
fixed: revert most of commit b4a39e243c2961c5a00e691469fcbe6a9f3c90a7

### DIFF
--- a/src/main/java/com/overstock/sample/processor/JpaProcessor.java
+++ b/src/main/java/com/overstock/sample/processor/JpaProcessor.java
@@ -56,6 +56,7 @@ public class JpaProcessor extends AbstractProcessor {
   private ElementTypePair entityType;
   private ElementTypePair oneToManyType;
   private ElementTypePair collectionType;
+  private ElementTypePair manyToOneType;
 
   private ExecutableElement mappedByAttribute;
 
@@ -71,6 +72,7 @@ public class JpaProcessor extends AbstractProcessor {
     entityType = getType("javax.persistence.Entity");
     oneToManyType = getType("javax.persistence.OneToMany");
     collectionType = getType("java.util.Collection");
+    manyToOneType = getType("javax.persistence.ManyToOne");
 
     mappedByAttribute = getMethod(oneToManyType.element, "mappedBy");
   }
@@ -227,7 +229,7 @@ public class JpaProcessor extends AbstractProcessor {
   private Element findParentReferenceInChildType(TypeMirror parentType, Element childType) {
     for (Element element: childType.getEnclosedElements()) {
       if (element.getKind() == ElementKind.FIELD || element.getKind() == ElementKind.METHOD) {
-        if (element.getAnnotation(ManyToOne.class) != null
+        if (getAnnotation(element, manyToOneType.type) != null
             && typeUtils().isSameType(parentType, getPropertyType(element))) {
           return element;
         }


### PR DESCRIPTION
Hi Ian, 

I reverted most of commit b4a39e243c2961c5a00e691469fcbe6a9f3c90a7 which used 

``` java
element.getAnnotation(ManyToOne.class)
```

That caused the processor to fail since javax.persistence.ManyToOne is not in its classpath.
I vaguely remember that happening in the talk and you fixing it as well.
