### PR TITLE
Make classpath robustly platform independent

### DIFF
--- a/src/test/java/com/overstock/sample/processor/Compiler.java
+++ b/src/test/java/com/overstock/sample/processor/Compiler.java
@@ -87,7 +87,15 @@ public class Compiler {
   }
 
   private static String classPathFor(Class<?> clazz) {
-    return clazz.getProtectionDomain().getCodeSource().getLocation().getFile();
+    URL url = clazz.getProtectionDomain().getCodeSource().getLocation();
+
+    try {
+      URI uri = url.toURI();
+
+      return Paths.get(uri).toFile().getAbsolutePath();
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   protected File writeSourceFile(SourceFile sourceFile) throws IOException {


### PR DESCRIPTION
The current implementation fails on Windows. This pull request solves the issue based on:

https://stackoverflow.com/a/17870390/2694806