### PR TITLE
Migrate from Java 1.6 to 1.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /target
 /.classpath
 /.project
+/.idea
+/*.iml
+/.vscode/

--- a/pom.xml
+++ b/pom.xml
@@ -3,6 +3,9 @@
   <groupId>com.overstock.sample</groupId>
   <artifactId>jpa-annotation-processor</artifactId>
   <version>trunk-SNAPSHOT</version>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.hibernate.javax.persistence</groupId>
@@ -45,9 +48,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <compilerArgument>-proc:none</compilerArgument>
         </configuration>
       </plugin>

--- a/src/main/java/com/overstock/sample/processor/JpaProcessor.java
+++ b/src/main/java/com/overstock/sample/processor/JpaProcessor.java
@@ -49,7 +49,7 @@ import javax.tools.Diagnostic.Kind;
  *
  */
 @SupportedAnnotationTypes({"javax.persistence.Entity", "javax.persistence.OneToMany"})
-@SupportedSourceVersion(SourceVersion.RELEASE_6)
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class JpaProcessor extends AbstractProcessor {
 
   // various types we'll want to refer to, initialized in init method

--- a/src/test/java/com/overstock/sample/processor/JpaProcessorTest.java
+++ b/src/test/java/com/overstock/sample/processor/JpaProcessorTest.java
@@ -8,6 +8,7 @@ import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
 import javax.tools.Diagnostic.Kind;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Matchers;
@@ -24,6 +25,11 @@ public class JpaProcessorTest {
     mockMessager = Mockito.mock(Messager.class);
     processor = new ProcessorWrapper(new JpaProcessor(), mockMessager);
     compiler = new Compiler();
+  }
+
+  @After
+  public void teardown() {
+    compiler.cleanUp();
   }
 
   @Test


### PR DESCRIPTION
The original intention was to implement a platform-independent way to build up the classpath for the compiler that is invoked during test. However, I encountered a few hairy issues and decided to approach them one by one. Therefore, this pull request can be summarised as:

- Adjust pom.xml and the annotation processor to use Java 1.8
- Add a few gitignore entries
- Add a JUnit After hook to clean up the temporary compiler output files

At this point, surprisingly all tests passed despite the issue I observed running on Windows yesterday. Specifically, on Windows `clazz.getProtectionDomain().getCodeSource().getLocation().getFile()` returns paths in the form "/C:/Foo/Bar/" (notice the "/" at the start of the line). My original goal was to implement a platform-independent way get this path. However, as-is, tests passed when running against a 8 JDK. So I decided not to commit my changes.

However, when I switched out my JDK to run against an 11 JDK, I had another issue and wasn't able to figure it out in a reasonable amount of time:

Caused by: java.lang.IllegalAccessError: superinterface check failed: class com.sun.tools.javac.processing.JavacProcessingEnvironment$$EnhancerByMockitoWithCGLIB$$2c456aaa_6 (in module jdk.compiler) cannot access class org.mockito.cglib.proxy.Factory (in unnamed module @0x1c72da34) because module jdk.compiler does not read unnamed module @0x1c72da34
